### PR TITLE
Add policy for provisioning cisagov/cyhy-tf-root

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# cool-accounts-cyhy #
+# cool-accounts-cyhy-tf-root #
 
-[![GitHub Build Status](https://github.com/cisagov/cool-accounts-cyhy/workflows/build/badge.svg)](https://github.com/cisagov/cool-accounts-cyhy/actions)
+[![GitHub Build Status](https://github.com/cisagov/cool-accounts-cyhy-tf-root/workflows/build/badge.svg)](https://github.com/cisagov/cool-accounts-cyhy-tf-root/actions)
 
 This project contains Terraform code to perform the initial configuration of a
 COOL Cyber Hygiene (CyHy) account. This Terraform code creates and configures
@@ -114,9 +114,11 @@ changes by simply running `terraform apply -var-file=<workspace_name>.tfvars`.
 
 | Name | Type |
 |------|------|
+| [aws_iam_policy.provisioncyhyroot_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.provisionlambdabucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.provisionssmsessionmanager_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.read_cool_lambda_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role_policy_attachment.provisioncyhyroot_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.provisionlambdabucket_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.provisionssmsessionmanager_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.read_cool_lambda_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -126,6 +128,7 @@ changes by simply running `terraform apply -var-file=<workspace_name>.tfvars`.
 | [aws_s3_bucket_server_side_encryption_configuration.lambda_artifacts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.lambda_artifacts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_caller_identity.cyhy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.provisioncyhyroot_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.provisionlambdabucket_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.provisionssmsessionmanager_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.read_cool_lambda_bucket_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -142,6 +145,8 @@ changes by simply running `terraform apply -var-file=<workspace_name>.tfvars`.
 | disable\_inactive\_users\_lambda\_key | The S3 key associated with the Lambda function deployment package to disable inactive IAM users. | `string` | n/a | yes |
 | provisionaccount\_role\_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the Cyber Hygiene account. | `string` | `"Allows sufficient permissions to provision all AWS resources in the Cyber Hygiene account."` | no |
 | provisionaccount\_role\_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the Cyber Hygiene account. | `string` | `"ProvisionAccount"` | no |
+| provisioncyhyroot\_policy\_description | The description to associate with the IAM policy that allows sufficient permissions to provision all AWS resources required by cisagov/cyhy-tf-root. | `string` | `"Allows sufficient permissions to provision all AWS resources required by cisagov/cyhy-tf-root."` | no |
+| provisioncyhyroot\_policy\_name | The name to assign the IAM policy that allows sufficient permissions to provision all AWS resources required by cisagov/cyhy-tf-root. | `string` | `"ProvisionCyHyRoot"` | no |
 | provisionlambdabucket\_policy\_description | The description to associate with the IAM policy that allows sufficient permissions to provision the Lambda deployment artifacts S3 bucket in the Cyber Hygiene account. | `string` | `"Allows sufficient permissions to provision the Lambda deployment artifacts S3 bucket in the Cyber Hygiene account."` | no |
 | provisionlambdabucket\_policy\_name | The name to assign the IAM policy that allows sufficient permissions to provision the Lambda deployment artifacts S3 bucket in the Cyber Hygiene account. | `string` | `"ProvisionLambdaArtifactsBucket"` | no |
 | provisionssmsessionmanager\_policy\_description | The description to associate with the IAM policy that allows sufficient permissions to provision the SSM Document resource and set up SSM session logging in the Cyber Hygiene account. | `string` | `"Allows sufficient permissions to provision the SSM Document resource and set up SSM session logging in the Cyber Hygiene account."` | no |

--- a/provisioncyhyroot_policy.tf
+++ b/provisioncyhyroot_policy.tf
@@ -1,0 +1,145 @@
+# ------------------------------------------------------------------------------
+# Create the IAM policy that allows all of the permissions necessary to
+# provision the resources required by cisagov/cyhy-tf-root.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "provisioncyhyroot_policy_doc" {
+  statement {
+    actions = [
+      "cloudwatch:DeleteAlarms",
+      "cloudwatch:ListTagsForResource",
+      "cloudwatch:PutMetricAlarm",
+      "cloudwatch:TagResource",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ec2:AllocateAddress",
+      "ec2:AssociateAddress",
+      "ec2:AssociateRouteTable",
+      "ec2:AttachInternetGateway",
+      "ec2:AuthorizeSecurityGroupEgress",
+      "ec2:AuthorizeSecurityGroupIngress",
+      "ec2:CreateInternetGateway",
+      "ec2:CreateNatGateway",
+      "ec2:CreateNetworkAcl",
+      "ec2:CreateNetworkAclEntry",
+      "ec2:CreateNetworkInterface",
+      "ec2:CreateRoute",
+      "ec2:CreateRouteTable",
+      "ec2:CreateSecurityGroup",
+      "ec2:CreateSubnet",
+      "ec2:CreateTags",
+      "ec2:CreateVpc",
+      "ec2:DeleteInternetGateway",
+      "ec2:DeleteKeyPair",
+      "ec2:DeleteNatGateway",
+      "ec2:DeleteNetworkAcl",
+      "ec2:DeleteNetworkAclEntry",
+      "ec2:DeleteNetworkInterface",
+      "ec2:DeleteRoute",
+      "ec2:DeleteRouteTable",
+      "ec2:DeleteSecurityGroup",
+      "ec2:DeleteSubnet",
+      "ec2:DeleteVpc",
+      "ec2:Describe*",
+      "ec2:DetachInternetGateway",
+      "ec2:DisassociateAddress",
+      "ec2:DisassociateRouteTable",
+      "ec2:DisassociateVpcCidrBlock",
+      "ec2:ImportKeyPair",
+      "ec2:ModifyAddressAttribute",
+      "ec2:ModifyInstanceAttribute",
+      "ec2:ModifyInstanceMetadataOptions",
+      "ec2:ModifySubnetAttribute",
+      "ec2:ModifyVpcAttribute",
+      "ec2:MonitorInstances",
+      "ec2:ReleaseAddress",
+      "ec2:ReplaceNetworkAclAssociation",
+      "ec2:ReplaceNetworkAclEntry",
+      "ec2:ReplaceRoute",
+      "ec2:ReplaceRouteTableAssociation",
+      "ec2:ReportInstanceStatus",
+      "ec2:ResetAddressAttribute",
+      "ec2:RevokeSecurityGroupEgress",
+      "ec2:RevokeSecurityGroupIngress",
+      "ec2:RunInstances",
+      "ec2:StartInstances",
+      "ec2:StopInstances",
+      "ec2:TerminateInstances",
+      "ec2:UpdateSecurityGroupRuleDescriptionsEgress",
+      "ec2:UpdateSecurityGroupRuleDescriptionsIngress",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "events:DescribeEventBus",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "logs:ListTagsForResource",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "rds:AddTagsToResource",
+      "rds:CreateDBCluster",
+      "rds:CreateDBClusterParameterGroup",
+      "rds:CreateDBInstance",
+      "rds:CreateDBSubnetGroup",
+      "rds:DeleteDBCluster",
+      "rds:DeleteDBClusterParameterGroup",
+      "rds:DeleteDBInstance",
+      "rds:DeleteDBSubnetGroup",
+      "rds:Describe*",
+      "rds:ListTagsForResource",
+      "rds:ModifyDBCluster",
+      "rds:ModifyDBClusterParameterGroup",
+      "rds:ModifyDBInstance",
+      "rds:ModifyDBSubnetGroup",
+      "rds:ModifyTagsOnResource",
+      "rds:RemoveTagsFromResource",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:GetObject",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.lambda_artifacts.arn}/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "provisioncyhyroot_policy" {
+  description = var.provisioncyhyroot_policy_description
+  name        = var.provisioncyhyroot_policy_name
+  policy      = data.aws_iam_policy_document.provisioncyhyroot_policy_doc.json
+}

--- a/provisioncyhyroot_policy.tf
+++ b/provisioncyhyroot_policy.tf
@@ -93,6 +93,16 @@ data "aws_iam_policy_document" "provisioncyhyroot_policy_doc" {
 
   statement {
     actions = [
+      "lambda:InvokeFunction",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    actions = [
       "logs:ListTagsForResource",
     ]
 

--- a/provisioncyhyroot_policy.tf
+++ b/provisioncyhyroot_policy.tf
@@ -46,6 +46,7 @@ data "aws_iam_policy_document" "provisioncyhyroot_policy_doc" {
       "ec2:DeleteRouteTable",
       "ec2:DeleteSecurityGroup",
       "ec2:DeleteSubnet",
+      "ec2:DeleteTags",
       "ec2:DeleteVpc",
       "ec2:Describe*",
       "ec2:DetachInternetGateway",

--- a/provisioncyhyroot_policy_attachment.tf
+++ b/provisioncyhyroot_policy_attachment.tf
@@ -1,0 +1,9 @@
+# ------------------------------------------------------------------------------
+# Attach to the ProvisionAccount role the IAM policy that allows provisioning of
+# the resources required by cisagov/cyhy-tf-root.
+# ------------------------------------------------------------------------------
+
+resource "aws_iam_role_policy_attachment" "provisioncyhyroot_policy_attachment" {
+  policy_arn = aws_iam_policy.provisioncyhyroot_policy.arn
+  role       = var.provisionaccount_role_name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -50,6 +50,18 @@ variable "provisionaccount_role_name" {
   type        = string
 }
 
+variable "provisioncyhyroot_policy_description" {
+  default     = "Allows sufficient permissions to provision all AWS resources required by cisagov/cyhy-tf-root."
+  description = "The description to associate with the IAM policy that allows sufficient permissions to provision all AWS resources required by cisagov/cyhy-tf-root."
+  type        = string
+}
+
+variable "provisioncyhyroot_policy_name" {
+  default     = "ProvisionCyHyRoot"
+  description = "The name to assign the IAM policy that allows sufficient permissions to provision all AWS resources required by cisagov/cyhy-tf-root."
+  type        = string
+}
+
 variable "provisionlambdabucket_policy_description" {
   default     = "Allows sufficient permissions to provision the Lambda deployment artifacts S3 bucket in the Cyber Hygiene account."
   description = "The description to associate with the IAM policy that allows sufficient permissions to provision the Lambda deployment artifacts S3 bucket in the Cyber Hygiene account."

--- a/variables.tf
+++ b/variables.tf
@@ -53,12 +53,14 @@ variable "provisionaccount_role_name" {
 variable "provisioncyhyroot_policy_description" {
   default     = "Allows sufficient permissions to provision all AWS resources required by cisagov/cyhy-tf-root."
   description = "The description to associate with the IAM policy that allows sufficient permissions to provision all AWS resources required by cisagov/cyhy-tf-root."
+  nullable    = false
   type        = string
 }
 
 variable "provisioncyhyroot_policy_name" {
   default     = "ProvisionCyHyRoot"
   description = "The name to assign the IAM policy that allows sufficient permissions to provision all AWS resources required by cisagov/cyhy-tf-root."
+  nullable    = false
   type        = string
 }
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds a policy that allows the provisioning of the resources in [cisagov/cyhy-tf-root](https://github.com/cisagov/cyhy-tf-root).

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Without this policy, we won't be able to apply the Terraform in [cisagov/cyhy-tf-root](https://github.com/cisagov/cyhy-tf-root).

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

After I created this policy, I verified that I was able to successfully `terraform apply` and `terraform destroy` all of the resources for https://github.com/cisagov/cyhy-tf-root/pull/12.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
